### PR TITLE
Pass User-Agent when downloading files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pass User-Agent when downloading files (#26)
+
 ## [0.2.4] - 2025-11-03
 
 ## Changed

--- a/src/hatch_openzim/files_install.py
+++ b/src/hatch_openzim/files_install.py
@@ -4,7 +4,7 @@ import tempfile
 import zipfile
 from pathlib import Path
 from typing import Any
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 try:
     import tomllib  # pyright: ignore[reportMissingTypeStubs]
@@ -220,7 +220,12 @@ def _download_file(url: str, download_to: Path):
     """downloads a file to a given location"""
     if not url.startswith(("http:", "https:")):
         raise ValueError("URL must start with 'http:' or 'https:'")
-    with urlopen(url) as response, open(download_to, "wb") as file:  # noqa: S310
+    req = Request(  # noqa: S310
+        url,
+        # explain we are compatible with "Mozilla"
+        headers={"User-Agent": "Mozilla/5.0"},
+    )
+    with urlopen(req) as response, open(download_to, "wb") as file:  # noqa: S310
         file.write(response.read())
 
 


### PR DESCRIPTION
In sotoki I've experienced files download failing with 403 ; passing `Mozilla/5.0` as `User-Agent` solved the issue.